### PR TITLE
fix: Android 15 BLE hook compatibility and AOSP source alignment

### DIFF
--- a/app/src/main/java/com/jingyu233/bluetoothhook/data/model/VirtualDevice.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/data/model/VirtualDevice.kt
@@ -35,7 +35,9 @@ data class VirtualDevice(
                 mac.matches(Regex("^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")) &&
                 rssi in -100..0 &&
                 advDataHex.matches(Regex("^[0-9A-Fa-f]*$")) &&
+                advDataHex.length % 2 == 0 &&
                 scanResponseHex.matches(Regex("^[0-9A-Fa-f]*$")) &&
+                scanResponseHex.length % 2 == 0 &&
                 isAdvDataValid() &&
                 intervalMs > 0
     }

--- a/app/src/main/java/com/jingyu233/bluetoothhook/hook/BluetoothScanHook.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/hook/BluetoothScanHook.kt
@@ -5,6 +5,7 @@ import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XSharedPreferences
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
+import java.lang.reflect.Method
 
 /**
  * 蓝牙扫描Hook核心类
@@ -16,8 +17,14 @@ class BluetoothScanHook(
 ) {
     companion object {
         private val TAG = Logger.Tags.HOOK_SCANNER
-        private const val CLASS_SCAN_CONTROLLER = "com.android.bluetooth.le_scan.ScanController"
         private const val METHOD_ON_SCAN_RESULT_INTERNAL = "onScanResultInternal"
+
+        // 不同Android版本/OEM可能使用不同的类名
+        private val CANDIDATE_CLASSES = arrayOf(
+            "com.android.bluetooth.le_scan.ScanController",
+            "com.android.bluetooth.le_scan.TransitionalScanHelper",
+            "com.android.bluetooth.gatt.ScanManager"
+        )
     }
 
     private lateinit var scanResultBuilder: ScanResultBuilder
@@ -31,13 +38,13 @@ class BluetoothScanHook(
             scanResultBuilder = ScanResultBuilder(classLoader)
             virtualDeviceInjector = VirtualDeviceInjector(scanResultBuilder, prefs)
 
-            // Hook主要方法
+            // Hook主要方法（尝试多个类名和方法签名）
             val hooked = hookScanResultInternal()
 
             if (hooked) {
-                Logger.Hook.i(TAG, "Successfully hooked ScanController.onScanResultInternal")
+                Logger.Hook.i(TAG, "Successfully hooked onScanResultInternal")
             } else {
-                Logger.Hook.e(TAG, "Failed to hook scan methods", null)
+                Logger.Hook.e(TAG, "Failed to hook scan methods - no matching class/method found", null)
             }
 
         } catch (e: Throwable) {
@@ -46,56 +53,84 @@ class BluetoothScanHook(
     }
 
     /**
-     * Hook ScanController.onScanResultInternal方法
-     * 这是逆向代码分析确定的最佳注入点（line 362）
+     * Hook onScanResultInternal方法
+     * 使用反射在运行时发现方法，兼容所有Android版本和OEM定制
      */
     private fun hookScanResultInternal(): Boolean {
-        return try {
-            val scanControllerClass = XposedHelpers.findClass(CLASS_SCAN_CONTROLLER, classLoader)
+        for (className in CANDIDATE_CLASSES) {
+            val clazz = try {
+                XposedHelpers.findClass(className, classLoader)
+            } catch (e: Throwable) {
+                Logger.Hook.i(TAG, "Class not found: $className, trying next...")
+                continue
+            }
 
-            // 查找方法（根据逆向代码分析的签名）
-            // onScanResultInternal(int eventType, int addressType, String address,
-            //                      int primaryPhy, int secondaryPhy, int advertisingSid,
-            //                      int txPower, int rssi, int periodicAdvInt,
-            //                      byte[] scanRecord, String originalAddress)
-            val method = XposedHelpers.findMethodBestMatch(
-                scanControllerClass,
-                METHOD_ON_SCAN_RESULT_INTERNAL,
-                Int::class.javaPrimitiveType,    // eventType
-                Int::class.javaPrimitiveType,    // addressType
-                String::class.java,              // address
-                Int::class.javaPrimitiveType,    // primaryPhy
-                Int::class.javaPrimitiveType,    // secondaryPhy
-                Int::class.javaPrimitiveType,    // advertisingSid
-                Int::class.javaPrimitiveType,    // txPower
-                Int::class.javaPrimitiveType,    // rssi
-                Int::class.javaPrimitiveType,    // periodicAdvInt
-                ByteArray::class.java,           // scanRecord
-                String::class.java               // originalAddress
-            )
+            // 通过反射查找所有名为onScanResultInternal的方法
+            val methods = findMethodsByName(clazz, METHOD_ON_SCAN_RESULT_INTERNAL)
+            if (methods.isEmpty()) {
+                Logger.Hook.i(TAG, "No $METHOD_ON_SCAN_RESULT_INTERNAL in $className, trying next class...")
+                continue
+            }
 
-            XposedBridge.hookMethod(method, object : XC_MethodHook() {
-                override fun afterHookedMethod(param: MethodHookParam) {
-                    try {
-                        // 在原方法执行完后注入虚拟设备
-                        injectVirtualDevices(param)
-                    } catch (e: Throwable) {
-                        // 捕获所有异常，避免影响真实扫描结果
-                        Logger.Hook.e(TAG, "Error during virtual device injection", e)
+            // 记录找到的所有方法签名（用于调试）
+            for (m in methods) {
+                val paramStr = m.parameterTypes.joinToString(",") { it.name }
+                Logger.Hook.i(TAG, "Found method: $className.$METHOD_ON_SCAN_RESULT_INTERNAL($paramStr)")
+            }
+
+            // Hook所有找到的重载方法
+            var hooked = false
+            for (method in methods) {
+                try {
+                    XposedBridge.hookMethod(method, object : XC_MethodHook() {
+                        override fun afterHookedMethod(param: MethodHookParam) {
+                            try {
+                                injectVirtualDevices(param)
+                            } catch (e: Throwable) {
+                                Logger.Hook.e(TAG, "Error during virtual device injection", e)
+                            }
+                        }
+                    })
+                    val paramStr = method.parameterTypes.joinToString(",") { it.name }
+                    Logger.Hook.i(TAG, "Hooked $className.$METHOD_ON_SCAN_RESULT_INTERNAL($paramStr)")
+                    hooked = true
+                } catch (e: Throwable) {
+                    Logger.Hook.e(TAG, "Failed to hook method variant in $className", e)
+                }
+            }
+
+            if (hooked) return true
+        }
+        return false
+    }
+
+    /**
+     * 通过反射查找类中所有指定名称的方法（包括父类中声明的）
+     */
+    private fun findMethodsByName(clazz: Class<*>, name: String): List<Method> {
+        val result = mutableListOf<Method>()
+        try {
+            // 搜索当前类和所有父类
+            var current: Class<*>? = clazz
+            while (current != null) {
+                for (method in current.declaredMethods) {
+                    if (method.name == name) {
+                        method.isAccessible = true
+                        result.add(method)
                     }
                 }
-            })
-
-            true
+                current = current.superclass
+            }
         } catch (e: Throwable) {
-            Logger.Hook.e(TAG, "Failed to hook $METHOD_ON_SCAN_RESULT_INTERNAL", e)
-            false
+            Logger.Hook.e(TAG, "Error finding methods by name: $name", e)
         }
+        return result
     }
 
     /**
      * 注入虚拟设备到扫描结果
      * 在真实扫描结果处理完后调用
+     * 兼容不同Android版本的类结构
      */
     private fun injectVirtualDevices(param: XC_MethodHook.MethodHookParam) {
         try {
@@ -108,30 +143,36 @@ class BluetoothScanHook(
                 return // 全局开关关闭，静默返回
             }
 
-            // 获取ScanController实例
-            val scanControllerInstance = param.thisObject
+            val instance = param.thisObject
 
-            // 获取mScanManager字段（根据逆向代码：line 410）
-            val scanManager = XposedHelpers.getObjectField(scanControllerInstance, "mScanManager")
-            if (scanManager == null) {
-                return
-            }
+            // 获取ScanManager：可能是字段(mScanManager)，也可能this本身就是ScanManager
+            val scanManager = getFieldSafe(instance, "mScanManager")
+                ?: getFieldSafe(instance, "mScanHelper")
+                ?: instance // 如果都没有，this本身可能就是ScanManager
 
-            // 获取mScannerMap字段
-            val scannerMap = XposedHelpers.getObjectField(scanControllerInstance, "mScannerMap")
+            // 获取ScannerMap：尝试多个可能的字段名
+            // TransitionalScanHelper: instance.mScannerMap
+            // ScanController (latest): instance.mScanHelper.mScannerMap
+            // ScanManager (older): scanManager.mScannerMap
+            val scannerMap = getFieldSafe(instance, "mScannerMap")
+                ?: getFieldSafe(scanManager, "mScannerMap")
+                ?: getFieldSafe(getFieldSafe(instance, "mScanHelper"), "mScannerMap")
+                ?: getFieldSafe(instance, "mAppScanStats")
             if (scannerMap == null) {
+                Logger.Hook.w(TAG, "Cannot find scannerMap field, skipping injection")
                 return
             }
 
-            // 获取当前扫描队列（line 410: mScanManager.getRegularScanQueue()）
-            val scanQueue = XposedHelpers.callMethod(scanManager, "getRegularScanQueue") as? Collection<*>
+            // 获取当前扫描队列：尝试多个可能的方法名
+            val scanQueue = callMethodSafe(scanManager, "getRegularScanQueue") as? Collection<*>
+                ?: callMethodSafe(scanManager, "getScanQueue") as? Collection<*>
             if (scanQueue == null || scanQueue.isEmpty()) {
                 return // 没有活跃的扫描客户端，静默返回
             }
 
             // 执行虚拟设备注入
             virtualDeviceInjector.injectDevices(
-                scanControllerInstance,
+                instance,
                 scanManager,
                 scannerMap,
                 scanQueue
@@ -139,6 +180,29 @@ class BluetoothScanHook(
 
         } catch (e: Throwable) {
             Logger.Hook.e(TAG, "Error in injectVirtualDevices", e)
+        }
+    }
+
+    /**
+     * 安全获取对象字段，不存在时返回null而非抛异常
+     */
+    private fun getFieldSafe(obj: Any?, fieldName: String): Any? {
+        if (obj == null) return null
+        return try {
+            XposedHelpers.getObjectField(obj, fieldName)
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * 安全调用方法，不存在时返回null而非抛异常
+     */
+    private fun callMethodSafe(obj: Any, methodName: String, vararg args: Any?): Any? {
+        return try {
+            XposedHelpers.callMethod(obj, methodName, *args)
+        } catch (e: Throwable) {
+            null
         }
     }
 }

--- a/app/src/main/java/com/jingyu233/bluetoothhook/hook/HookEntry.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/hook/HookEntry.kt
@@ -59,9 +59,6 @@ class HookEntry : IXposedHookLoadPackage {
             val bluetoothScanHook = BluetoothScanHook(lpparam.classLoader, prefs)
             bluetoothScanHook.init()
 
-            // 写入Hook状态标记（供UI进程读取）
-            writeHookStatus()
-
             Logger.Hook.i(TAG, "BluetoothHook initialized successfully")
 
         } catch (e: Throwable) {
@@ -102,32 +99,6 @@ class HookEntry : IXposedHookLoadPackage {
             )
         } catch (e: Throwable) {
             Logger.Hook.e(TAG, "Failed to hook module application", e)
-        }
-    }
-
-    /**
-     * 写入Hook状态到文件系统
-     * Hook进程运行在系统进程中,使用 /data/system 目录以避免 SELinux 权限问题
-     */
-    private fun writeHookStatus() {
-        try {
-            // 方案1: 尝试写入系统可访问的目录
-            val statusFile = java.io.File("/data/system/bluetooth_hook_status.txt")
-
-            // 写入状态和时间戳
-            val statusData = "Active|${System.currentTimeMillis()}"
-            statusFile.writeText(statusData)
-
-            // 设置文件权限为全局可读（0644）
-            try {
-                Runtime.getRuntime().exec("chmod 644 ${statusFile.absolutePath}").waitFor()
-            } catch (e: Exception) {
-                Logger.Hook.w(TAG, "Failed to set file permissions: ${e.message}")
-            }
-
-            Logger.Hook.d(TAG, "Hook status written to /data/system: $statusData")
-        } catch (e: Exception) {
-            Logger.Hook.e(TAG, "Failed to write hook status file", e)
         }
     }
 }

--- a/app/src/main/java/com/jingyu233/bluetoothhook/hook/ScanResultBuilder.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/hook/ScanResultBuilder.kt
@@ -71,10 +71,11 @@ class ScanResultBuilder(private val classLoader: ClassLoader) {
             val timestampNanos = SystemClock.elapsedRealtimeNanos()
 
             // 确定事件类型
+            // AOSP flags: ET_LEGACY_ADV=0x0010, ET_CONNECTABLE=0x0001, ET_SCANNABLE=0x0002
             val eventType = if (useExtendedAdvertising) {
-                0x00  // EXTENDED_ADVERTISING
+                0x01  // CONNECTABLE extended advertising
             } else {
-                0x10  // LEGACY_ADVERTISING
+                0x13  // LEGACY | CONNECTABLE | SCANNABLE
             }
 
             // 尝试使用完整参数的构造器
@@ -82,11 +83,11 @@ class ScanResultBuilder(private val classLoader: ClassLoader) {
                 XposedHelpers.newInstance(
                     scanResultClass,
                     device,                  // BluetoothDevice
-                    eventType,               // eventType: 0x10 = LEGACY, 0x00 = EXTENDED
+                    eventType,               // eventType: 0x13 = LEGACY, 0x01 = EXTENDED
                     1,                       // primaryPhy: 1 = LE 1M
                     if (useExtendedAdvertising) 1 else 0,  // secondaryPhy: 1 = LE 1M, 0 = None
-                    255,                     // advertisingSid: 255 = Not periodic
-                    0,                       // txPower: 0 = Unknown
+                    255,                     // advertisingSid: 255 = SID_NOT_PRESENT
+                    127,                     // txPower: 127 = TX_POWER_NOT_PRESENT (0x7F)
                     rssi,                    // rssi
                     0,                       // periodicAdvInt: 0 = None
                     scanRecord,              // ScanRecord
@@ -113,7 +114,12 @@ class ScanResultBuilder(private val classLoader: ClassLoader) {
      * 十六进制字符串转字节数组
      */
     private fun hexStringToByteArray(hexString: String): ByteArray {
-        val cleanHex = hexString.replace(" ", "").replace(":", "")
+        var cleanHex = hexString.replace(" ", "").replace(":", "")
+        // 奇数长度时截断最后一个字符，确保成对解析
+        if (cleanHex.length % 2 != 0) {
+            Logger.Hook.w(TAG, "Odd-length hex string (${cleanHex.length} chars), truncating last nibble")
+            cleanHex = cleanHex.substring(0, cleanHex.length - 1)
+        }
         val len = cleanHex.length
         val data = ByteArray(len / 2)
 

--- a/app/src/main/java/com/jingyu233/bluetoothhook/hook/VirtualDeviceInjector.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/hook/VirtualDeviceInjector.kt
@@ -48,8 +48,9 @@ class VirtualDeviceInjector(
             }
 
             // 解析虚拟设备列表
+            val json = Json { ignoreUnknownKeys = true }
             val devices = try {
-                Json.decodeFromString<List<VirtualDeviceData>>(devicesJson)
+                json.decodeFromString<List<VirtualDeviceData>>(devicesJson)
             } catch (e: Exception) {
                 // 只在首次解析失败时输出错误，避免刷屏
                 Logger.Hook.e(TAG, "JSON parse error: ${e.message}\nJSON: $devicesJson", e)
@@ -135,7 +136,7 @@ class VirtualDeviceInjector(
 
     /**
      * 将ScanResult发送给扫描客户端
-     * 根据逆向代码line 466: iScannerCallback.onScanResult(scanResult)
+     * 兼容不同Android版本的字段/方法名
      */
     private fun deliverToClient(
         scanClient: Any,
@@ -143,17 +144,28 @@ class VirtualDeviceInjector(
         scanResult: Any
     ) {
         try {
-            // 获取scannerId
-            val scannerId = XposedHelpers.getIntField(scanClient, "mScannerId")
+            // 获取scannerId：先尝试字段访问（更快，android-15.0.0_r1 Java），再尝试getter（Kotlin版本）
+            val scannerId = try {
+                XposedHelpers.getIntField(scanClient, "scannerId")
+            } catch (e: Throwable) {
+                try {
+                    XposedHelpers.callMethod(scanClient, "getScannerId") as Int
+                } catch (e2: Throwable) {
+                    XposedHelpers.getIntField(scanClient, "mScannerId")
+                }
+            }
 
             // 通过scannerMap获取ScannerApp
             val scannerApp = XposedHelpers.callMethod(scannerMap, "getById", scannerId)
                 ?: return
 
-            // 获取IScannerCallback
-            val callback = XposedHelpers.getObjectField(scannerApp, "mCallback")
+            // 获取IScannerCallback：先尝试字段callback，再尝试mCallback
+            val callback = try {
+                XposedHelpers.getObjectField(scannerApp, "callback")
+            } catch (e: Throwable) {
+                XposedHelpers.getObjectField(scannerApp, "mCallback")
+            }
             if (callback == null) {
-                // 有些客户端使用PendingIntent而不是callback
                 return
             }
 
@@ -161,7 +173,6 @@ class VirtualDeviceInjector(
             XposedHelpers.callMethod(callback, "onScanResult", scanResult)
 
         } catch (e: Throwable) {
-            // 某些客户端可能已断开连接，抛出异常让上层处理
             throw e
         }
     }

--- a/app/src/main/java/com/jingyu233/bluetoothhook/ui/viewmodel/DeviceEditorViewModel.kt
+++ b/app/src/main/java/com/jingyu233/bluetoothhook/ui/viewmodel/DeviceEditorViewModel.kt
@@ -228,10 +228,14 @@ class DeviceEditorViewModel(
 
         if (!currentDevice.advDataHex.matches(Regex("^[0-9A-Fa-f]*$"))) {
             errors["advData"] = "广播数据只能包含十六进制字符"
+        } else if (currentDevice.advDataHex.length % 2 != 0) {
+            errors["advData"] = "广播数据长度必须为偶数（每字节2个十六进制字符）"
         }
 
         if (!currentDevice.scanResponseHex.matches(Regex("^[0-9A-Fa-f]*$"))) {
-            errors["advData"] = "扫描响应数据只能包含十六进制字符"
+            errors["scanResponse"] = "扫描响应数据只能包含十六进制字符"
+        } else if (currentDevice.scanResponseHex.length % 2 != 0) {
+            errors["scanResponse"] = "扫描响应数据长度必须为偶数（每字节2个十六进制字符）"
         }
 
         // 根据模式验证数据长度


### PR DESCRIPTION
---- AI总结
- Hook target: use runtime reflection to discover onScanResultInternal across ScanController, TransitionalScanHelper, and ScanManager
- ScanResult: fix eventType (0x10→0x13 LEGACY|CONNECTABLE|SCANNABLE), txPower (0→127 TX_POWER_NOT_PRESENT)
- VirtualDeviceInjector: reorder scannerId access (field-first for android-15.0.0_r1 ScanClient.scannerId), add ignoreUnknownKeys
- BluetoothScanHook: add mScanHelper.mScannerMap fallback for latest ScanController, null-safe getFieldSafe
- HookEntry: remove writeHookStatus (always EACCES in bluetooth process)
- Validation: enforce even-length hex in VirtualDevice and editor UI, fix scanResponse error key typo
----
我遇到了和https://github.com/jingyu233/BluetoothHook/issues/4差不多的问题
不过我的机型是OnePlus Ace 5，我使用了Claude Code在Opus 4.6模型下修复了这一点，但是我也只有这一台设备，缺乏对其他设备的测试，可以根据代码和测试结果进行部分合并
XD